### PR TITLE
Fix space needed after Unops (like "not")

### DIFF
--- a/language-lua2.cabal
+++ b/language-lua2.cabal
@@ -1,5 +1,5 @@
 name:                   language-lua2
-version:                0.1.0.6
+version:                0.1.0.7
 synopsis:               Lua parser and pretty printer
 description:            Lua parser and pretty printer
 homepage:               http://github.com/mitchellwrosen/language-lua2

--- a/src/Language/Lua/Syntax.hs
+++ b/src/Language/Lua/Syntax.hs
@@ -308,7 +308,7 @@ instance Pretty (Expression a) where
     pretty (PrefixExp _ e)    = pretty e
     pretty (TableCtor _ t)    = pretty t
     pretty (Binop _ op e1 e2) = pretty e1 <+> pretty op <+> pretty e2
-    pretty (Unop _ op e)      = pretty op <> pretty e
+    pretty (Unop _ op e)      = pretty op <+> pretty e
 
 instance Pretty (PrefixExpression a) where
     pretty (PrefixVar _ v)     = pretty v


### PR DESCRIPTION
The following AST

```
L.Unop () (L.Not ())
          (L.PrefixExp ()
                       (L.PrefixVar ()
                                    (L.VarIdent ()
                                                (L.Ident () "foo"))))
```

was wrongly rendered as `notfoo` instead of `not foo`.
